### PR TITLE
Fix ValueError in TraceParser when parameter value contains ' = '

### DIFF
--- a/src/firebird/lib/trace.py
+++ b/src/firebird/lib/trace.py
@@ -1383,7 +1383,7 @@ class TraceParser:
         parameters = []
         while self.__current_block and self.__current_block[0].startswith('param'):
             line = self.__current_block.popleft()
-            _, param_def = line.split(' = ')
+            _, param_def = line.split(' = ', maxsplit=1)
             parameters.append(self._parse_value_spec(param_def))
         return parameters
     def _parse_parameters(self, *, for_procedure: bool=False) -> None:

--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -513,3 +513,48 @@ EventTransactionStart(event_id=2, timestamp=datetime.datetime(2014, 5, 23, 11, 0
 EventCommit(event_id=3, timestamp=datetime.datetime(2014, 5, 23, 11, 0, 30, 435000), status=<Status.OK: ' '>, attachment_id=8, transaction_id=1568, options=['READ_COMMITTED', 'REC_VERSION', 'WAIT', 'READ_WRITE'], run_time=5, reads=10, writes=2, fetches=None, marks=None)
 """
     _check_events(trace_lines, output)
+
+def test_68_param_value_containing_equals():
+    """Tests parsing of a parameter whose value contains the ' = ' substring.
+
+    Without ``maxsplit=1`` on ``line.split(' = ')`` in
+    ``_parse_parameters_block``, a parameter value that itself contains
+    ``' = '`` causes ``ValueError: too many values to unpack (expected 2,
+    got 3)`` and the enclosing trace block is dropped silently. Such
+    values are entirely legal -- a varchar column can carry arbitrary
+    text, including key=value-shaped strings.
+    """
+    trace_lines = """2014-05-23T11:00:28.5840 (3720:0000000000EFD9E8) ATTACH_DATABASE
+	/home/employee.fdb (ATT_8, SYSDBA:NONE, ISO88591, TCPv4:192.168.1.5)
+	/opt/firebird/bin/isql:8723
+
+2014-05-23T11:00:28.6160 (3720:0000000000EFD9E8) START_TRANSACTION
+	/home/employee.fdb (ATT_8, SYSDBA:NONE, ISO88591, TCPv4:192.168.1.5)
+	/opt/firebird/bin/isql:8723
+		(TRA_1568, READ_COMMITTED | REC_VERSION | WAIT | READ_WRITE)
+
+2014-05-23T11:00:30.4350 (3720:0000000000EFD9E8) EXECUTE_STATEMENT_FINISH
+	/home/employee.fdb (ATT_8, SYSDBA:NONE, ISO88591, TCPv4:192.168.1.5)
+	/opt/firebird/bin/isql:8723
+		(TRA_1568, READ_COMMITTED | REC_VERSION | WAIT | READ_WRITE)
+
+Statement 1:
+-------------------------------------------------------------------------------
+UPDATE NOTES SET BODY = ? WHERE ID = ?
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+param0 = varchar(80), "alpha = 1; beta = 2"
+param1 = integer, "42"
+
+0 records fetched
+      15 ms, 147 read(s), 1 write(s), 6 fetch(es)
+
+"""
+    # Parameter value 'alpha = 1; beta = 2' contains ' = ' twice.
+    # The block must parse cleanly and the value must be preserved verbatim.
+    output = """EventAttach(event_id=1, timestamp=datetime.datetime(2014, 5, 23, 11, 0, 28, 584000), status=<Status.OK: ' '>, attachment_id=8, database='/home/employee.fdb', charset='ISO88591', protocol='TCPv4', address='192.168.1.5', user='SYSDBA', role='NONE', remote_process='/opt/firebird/bin/isql', remote_pid=8723)
+EventTransactionStart(event_id=2, timestamp=datetime.datetime(2014, 5, 23, 11, 0, 28, 616000), status=<Status.OK: ' '>, attachment_id=8, transaction_id=1568, options=['READ_COMMITTED', 'REC_VERSION', 'WAIT', 'READ_WRITE'])
+ParamSet(par_id=1, params=[('varchar(80)', 'alpha = 1; beta = 2'), ('integer', 42)])
+SQLInfo(sql_id=1, sql='UPDATE NOTES SET BODY = ? WHERE ID = ?', plan='')
+EventStatementFinish(event_id=3, timestamp=datetime.datetime(2014, 5, 23, 11, 0, 30, 435000), status=<Status.OK: ' '>, attachment_id=8, transaction_id=1568, statement_id=1, sql_id=1, param_id=1, records=0, run_time=15, reads=147, writes=1, fetches=6, marks=None, access=None)
+"""
+    _check_events(trace_lines, output)


### PR DESCRIPTION
## Summary

`TraceParser._parse_parameters_block` (in `src/firebird/lib/trace.py`) calls `line.split(' = ')` without a `maxsplit` argument. When a parameter line's **value** itself contains the substring ` = ` &mdash; entirely legal, since a `varchar` column can carry arbitrary text, including key=value-shaped strings &mdash; the split yields 3+ parts and the unpacking on the same line raises:

```
ValueError: too many values to unpack (expected 2, got N)
```

Because `_parse_parameters_block` is called from `_parse_parameters` and from `__parser_func_finish` (the `returns:` block of function-finish events), the failure silently drops the enclosing trace block on **every** event that carries parameters or function-return values. The error propagates out of `parse_event`, but typical streaming consumers swallow it per-block, and one bad row eats real telemetry.

## Repro

A trace block with a parameter whose value contains ` = `, e.g. `param0 = varchar(80), \"alpha = 1; beta = 2\"`, triggers the ValueError before the fix. Added as `test_68_param_value_containing_equals` in `tests/test_trace.py`; without the patch, the new test fails at line 1386 with `ValueError: too many values to unpack (expected 2, got 4)`. With the patch, all 21 tests in `test_trace.py` pass.

## Fix

One-character change: `line.split(' = ', maxsplit=1)`. The second ` = ` (and any after) stays inside the value, where it belongs. The expected `(name, value)` shape of the unpacking is preserved.

```diff
-            _, param_def = line.split(' = ')
+            _, param_def = line.split(' = ', maxsplit=1)
```

Both call sites of `_parse_parameters_block` (in `_parse_parameters` at line ~1390 and in `__parser_func_finish` at line ~1755) inherit the fix.

## Out of scope

Multi-line parameter values that span multiple `__current_block` entries (line continuation) are a separate parsing concern and are not addressed here.

## Test plan

- [x] `pytest tests/test_trace.py` passes (21/21) with the fix applied.
- [x] Reverting the fix while keeping the new test causes `test_68_param_value_containing_equals` to fail with the expected `ValueError` at the patched line.
- [ ] CI green on this PR.